### PR TITLE
refactor: simplify tool names in BuiltInToolProvider for consistency

### DIFF
--- a/src-tauri/src/mcp/builtin/filesystem.rs
+++ b/src-tauri/src/mcp/builtin/filesystem.rs
@@ -822,7 +822,7 @@ impl FilesystemServer {
 #[async_trait]
 impl BuiltinMCPServer for FilesystemServer {
     fn name(&self) -> &str {
-        "builtin.filesystem"
+        "filesystem"
     }
 
     fn description(&self) -> &str {

--- a/src-tauri/src/mcp/builtin/mod.rs
+++ b/src-tauri/src/mcp/builtin/mod.rs
@@ -76,11 +76,8 @@ impl BuiltinServerRegistry {
         let mut all_tools = Vec::new();
 
         for server in self.servers.values() {
-            let mut tools = server.tools();
+            let tools = server.tools();
             // Prefix tool names with server name for uniqueness
-            for tool in &mut tools {
-                tool.name = format!("{}__{}", server.name(), tool.name);
-            }
             all_tools.extend(tools);
         }
 

--- a/src-tauri/src/mcp/builtin/sandbox.rs
+++ b/src-tauri/src/mcp/builtin/sandbox.rs
@@ -623,7 +623,7 @@ impl SandboxServer {
 #[async_trait]
 impl BuiltinMCPServer for SandboxServer {
     fn name(&self) -> &str {
-        "builtin.sandbox"
+        "sandbox"
     }
 
     fn description(&self) -> &str {

--- a/src/features/tools/BrowserToolProvider.tsx
+++ b/src/features/tools/BrowserToolProvider.tsx
@@ -36,7 +36,7 @@ export function BrowserToolProvider() {
 
     const browserTools: LocalMCPTool[] = [
       {
-        name: 'browser_createSession',
+        name: 'createSession',
         description:
           'Creates a new interactive browser session in a separate window.',
         inputSchema: {
@@ -64,7 +64,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_closeSession',
+        name: 'closeSession',
         description: 'Closes an existing browser session and its window.',
         inputSchema: {
           type: 'object',
@@ -86,7 +86,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_listSessions',
+        name: 'listSessions',
         description: 'Lists all active browser sessions.',
         inputSchema: {
           type: 'object',
@@ -100,7 +100,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_getPageContent',
+        name: 'getPageContent',
         description:
           'Extracts clean content from the page as Markdown, and saves the raw HTML to a temporary file for reference.',
         inputSchema: {
@@ -184,7 +184,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_clickElement',
+        name: 'clickElement',
         description: 'Clicks on a DOM element using CSS selector.',
         inputSchema: {
           type: 'object',
@@ -227,7 +227,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_inputText',
+        name: 'inputText',
         description: 'Inputs text into a form field using CSS selector.',
         inputSchema: {
           type: 'object',
@@ -274,7 +274,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_getCurrentUrl',
+        name: 'getCurrentUrl',
         description: 'Gets the current URL of the browser page.',
         inputSchema: {
           type: 'object',
@@ -293,7 +293,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_getPageTitle',
+        name: 'getPageTitle',
         description: 'Gets the title of the current browser page.',
         inputSchema: {
           type: 'object',
@@ -312,7 +312,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_elementExists',
+        name: 'elementExists',
         description: 'Checks if a DOM element exists using CSS selector.',
         inputSchema: {
           type: 'object',
@@ -351,7 +351,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_scrollPage',
+        name: 'scrollPage',
         description: 'Scrolls the page to specified coordinates.',
         inputSchema: {
           type: 'object',
@@ -383,7 +383,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_navigateToUrl',
+        name: 'navigateToUrl',
         description: 'Navigates to a new URL in an existing browser session.',
         inputSchema: {
           type: 'object',
@@ -413,7 +413,7 @@ export function BrowserToolProvider() {
         },
       },
       {
-        name: 'browser_extractStructuredContent',
+        name: 'extractStructuredContent',
         description:
           'Extracts clean, structured content from the page as JSON, removing styling and focusing on meaningful content.',
         inputSchema: {


### PR DESCRIPTION
This pull request standardizes tool and server naming conventions by removing redundant prefixes, making tool names more concise and consistent across the codebase. The most significant changes involve updating tool names in the browser tool provider and server names in the Rust backend, which improves clarity and reduces unnecessary repetition.

**Naming convention updates:**

* All browser tool names in `BrowserToolProvider.tsx` have been changed to remove the `browser_` prefix, resulting in simpler names like `createSession`, `closeSession`, `clickElement`, etc. [[1]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L39-R39) [[2]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L67-R67) [[3]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L89-R89) [[4]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L103-R103) [[5]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L187-R187) [[6]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L230-R230) [[7]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L277-R277) [[8]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L296-R296) [[9]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L315-R315) [[10]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L354-R354) [[11]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L386-R386) [[12]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L416-R416)

* Server names in Rust implementations have been updated to remove the `builtin.` prefix, changing `"builtin.filesystem"` to `"filesystem"` in `filesystem.rs` and `"builtin.sandbox"` to `"sandbox"` in `sandbox.rs`. [[1]](diffhunk://#diff-4cacb3ae6d7e66e244b28767f3f790eb8c194177f0a6b745f80cd300e694a0feL825-R825) [[2]](diffhunk://#diff-dfd82dcf9c7edaa2f81dd8dba3aeccc30c99496de6edcd92b98a3eed8392a3d9L626-R626)

**Tool registration logic:**

* The logic for tool name prefixing in `mod.rs` was removed, so tool names are no longer automatically prefixed with the server name for uniqueness.