### PR TITLE
fix(ci): install rustfmt before format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
         if: github.event_name == 'pull_request'
         run: cd src-tauri && cargo clippy -- -D warnings
 
+      - name: 🦀 Install rustfmt
+        run: rustup component add rustfmt
       - name: 🎨 Rust Format Check (PR)
         if: github.event_name == 'pull_request'
         run: cd src-tauri && cargo fmt --check


### PR DESCRIPTION
This pull request updates the CI workflow to ensure Rust code formatting checks run reliably. The main change is the addition of a step to install the `rustfmt` component before running the format check.

Rust code quality and formatting:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR79-R80): Added a step to install `rustfmt` using `rustup component add rustfmt` before running the Rust format check in pull request workflows.