### PR TITLE
Dev/0.1.1

### DIFF
--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -207,6 +207,21 @@ function SessionContextProvider({ children }: { children: ReactNode }) {
    */
   const handleSelect = useCallback(
     (id?: string) => {
+      // Notify other parts of the app that the session is switching so they can
+      // abort any in-flight operations immediately.
+      if (typeof window !== 'undefined') {
+        try {
+          window.dispatchEvent(
+            new CustomEvent('synapticflow:session-switch', {
+              detail: { sessionId: id },
+            }),
+          );
+        } catch {
+          // Fail silently if CustomEvent is not supported in the environment
+          // (very unlikely in browser runtimes)
+        }
+      }
+
       if (id === undefined) {
         setCurrent(null);
         // Session backend management is now handled by BuiltInToolProvider

--- a/src/context/SessionHistoryContext.tsx
+++ b/src/context/SessionHistoryContext.tsx
@@ -103,10 +103,10 @@ export function SessionHistoryProvider({ children }: { children: ReactNode }) {
     (messagesToAdd: Message[]): Promise<Message[]> => {
       if (!currentSession) throw new Error('No active session.');
       messagesToAdd.forEach(validateMessage);
-      const messagesWithSessionId = messagesToAdd.map((m) => ({
-        ...m,
-        sessionId: currentSession.id,
-      }));
+      const messagesWithSessionId = messagesToAdd.map((m) => {
+        if (!m.sessionId) return { ...m, sessionId: currentSession.id };
+        return m; // Preserve existing sessionId from origin
+      });
 
       const previousData = data;
 

--- a/src/hooks/use-ai-service.ts
+++ b/src/hooks/use-ai-service.ts
@@ -314,5 +314,12 @@ export const useAIService = (config?: AIServiceConfig) => {
     [model, provider, config, serviceInstance],
   );
 
-  return { response, isLoading, error, submit };
+  const cancel = useCallback(() => {
+    logger.info('Cancelling AI service request');
+    serviceInstance.cancel();
+    setIsLoading(false);
+    setError(null);
+  }, [serviceInstance]);
+
+  return { response, isLoading, error, submit, cancel };
 };

--- a/src/lib/ai-service/empty.ts
+++ b/src/lib/ai-service/empty.ts
@@ -27,6 +27,10 @@ export class EmptyAIService extends BaseAIService {
    * does not support chat streaming.
    */
   async *streamChat(): AsyncGenerator<string, void, void> {
+    if (this.getAbortSignal().aborted) {
+      this.logger.info('EmptyAIService stream cancelled before starting.');
+      return;
+    }
     yield '';
     throw new AIServiceError(
       `EmptyAIService does not support streaming chat`,

--- a/src/lib/ai-service/gemini.ts
+++ b/src/lib/ai-service/gemini.ts
@@ -121,7 +121,17 @@ export class GeminiService extends BaseAIService {
         });
       });
 
+      if (this.getAbortSignal().aborted) {
+        this.logger.info('Stream aborted before iteration');
+        return;
+      }
+
       for await (const chunk of result) {
+        if (this.getAbortSignal().aborted) {
+          this.logger.info('Stream aborted during iteration');
+          break;
+        }
+
         logger.info('chunk : ', { chunk });
         if (chunk.functionCalls && chunk.functionCalls.length > 0) {
           const validFunctionCalls = chunk.functionCalls.filter(

--- a/src/lib/ai-service/groq.ts
+++ b/src/lib/ai-service/groq.ts
@@ -78,7 +78,17 @@ export class GroqService extends BaseAIService {
         }),
       );
 
+      if (this.getAbortSignal().aborted) {
+        this.logger.info('Stream aborted before iteration');
+        return;
+      }
+
       for await (const chunk of chatCompletion) {
+        if (this.getAbortSignal().aborted) {
+          this.logger.info('Stream aborted during iteration');
+          break;
+        }
+
         if (chunk.choices[0]?.delta?.reasoning) {
           yield JSON.stringify({ thinking: chunk.choices[0].delta.reasoning });
         } else if (chunk.choices[0]?.delta?.tool_calls) {

--- a/src/lib/ai-service/types.ts
+++ b/src/lib/ai-service/types.ts
@@ -103,6 +103,16 @@ export interface IAIService {
   listModels(): Promise<ModelInfo[]>;
 
   /**
+   * Cancels any in-progress streaming requests initiated by `streamChat`.
+   * Implementations should abort network requests and stop yielding further
+   * values from `streamChat` as soon as possible.
+   *
+   * This method is idempotent - calling it multiple times or calling it
+   * when no stream is active should be safe and have no effect.
+   */
+  cancel(): void;
+
+  /**
    * Cleans up any resources used by the service instance.
    */
   dispose(): void;


### PR DESCRIPTION
This pull request introduces robust, unified support for AI stream cancellation across all AI service providers. The changes ensure that when a user switches sessions or explicitly cancels, any in-progress AI streaming requests are reliably aborted, preventing stray UI updates and resource leaks. The implementation standardizes cancellation at the service level, propagates cancellation through React context and hooks, and improves error handling for user-initiated aborts.

**AI Service Cancellation Infrastructure**

* Added a `cancel()` method to the `IAIService` interface and implemented it in `BaseAIService`, providing an instance-level `AbortController` to manage stream cancellation. The method is idempotent and ensures network requests are aborted promptly. (`src/lib/ai-service/types.ts`, `src/lib/ai-service/base-service.ts`) [[1]](diffhunk://#diff-14fc56012fc5edcf754ca1c1aa22d4a50c294ed941c121657b5c954c91106525R105-R114) [[2]](diffhunk://#diff-e6b0e90c67c4cc8c465348432344711f2f496cf95f6eedc2b70c71ab40093318R44-R46) [[3]](diffhunk://#diff-e6b0e90c67c4cc8c465348432344711f2f496cf95f6eedc2b70c71ab40093318R60-R74)
* All AI service subclasses (`AnthropicService`, `CerebrasService`, `GeminiService`, `GroqService`, `OllamaService`, `OpenAIService`, `EmptyAIService`) now respect the abort signal and gracefully halt streaming when cancelled, logging appropriate messages. Ollama’s implementation also calls its client’s abort method. (`src/lib/ai-service/anthropic.ts`, `src/lib/ai-service/cerebras.ts`, `src/lib/ai-service/gemini.ts`, `src/lib/ai-service/groq.ts`, `src/lib/ai-service/ollama.ts`, `src/lib/ai-service/openai.ts`, `src/lib/ai-service/empty.ts`) [[1]](diffhunk://#diff-8be7cb4419b940c9037e1b9d7441d4260e469451371e4169cae64936dca301e7L110-L118) [[2]](diffhunk://#diff-22635f42e85339e4646942da129f4a250139d4d4b23756e77ac86c690c49ee4cL108-R130) [[3]](diffhunk://#diff-e02ecdf2ff835f1f65b4efccc8452b9e1b13493ab461fa51a592844d2fcc9b15R124-R134) [[4]](diffhunk://#diff-c931724fee0c2967ca537abf9b78511e6187663d71d471dece63dd143bdf3989R81-R91) [[5]](diffhunk://#diff-26d9310a115f6f4f51802ffc2dd62f877f6d2c614f56f50ecc6050bee745cf10R104-R113) [[6]](diffhunk://#diff-26d9310a115f6f4f51802ffc2dd62f877f6d2c614f56f50ecc6050bee745cf10R202-R222) [[7]](diffhunk://#diff-34732a40c935733397b6329a3fd8802310290f58bc7694f04564d6e04ed993d9L173-R196) [[8]](diffhunk://#diff-0152450fb6e1cc1f2057f7c0c793c67b9442effb7b12702a2cbb7b5ce581d315R30-R33)

**React Context and Hook Integration**

* The `useAIService` hook now exposes a `cancel` method, which is invoked from the UI to abort in-flight requests and reset loading/error state. (`src/hooks/use-ai-service.ts`)
* `ChatProvider` in `ChatContext.tsx` calls `cancelAIService` on session changes and user-initiated cancels, ensuring all streaming and queue state is cleared and preventing race conditions or stale UI. (`src/context/ChatContext.tsx`) [[1]](diffhunk://#diff-b7fad6f22707098977cf6d05893252bb3660364770e1ad3e7b8b1569ff54eeaaR210-R236) [[2]](diffhunk://#diff-b7fad6f22707098977cf6d05893252bb3660364770e1ad3e7b8b1569ff54eeaaR503-R514)
* The session switching routine in `SessionContext.tsx` now dispatches a browser event (`synapticflow:session-switch`) to allow other components to abort operations immediately. (`src/context/SessionContext.tsx`)

**Error Handling and Message Management**

* Improved error handling in `BaseAIService` to distinguish user-initiated cancellations from genuine errors, logging and propagating them as expected, non-fatal events. (`src/lib/ai-service/base-service.ts`)
* Message saving routines now preserve existing `sessionId` fields when present, ensuring correct attribution in multi-session scenarios. (`src/context/ChatContext.tsx`, `src/context/SessionHistoryContext.tsx`) [[1]](diffhunk://#diff-b7fad6f22707098977cf6d05893252bb3660364770e1ad3e7b8b1569ff54eeaaL320-R333) [[2]](diffhunk://#diff-104573a3878a89d297918880a8cfdf249202c6795da729f0b84531b0f72026edL106-R109)

These changes significantly improve the reliability and user experience of chat session management, especially when switching sessions or cancelling requests.